### PR TITLE
update to allow python3 package to override py2 and vice-versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Reverse Proxy Listing API Implementation Changelog
 
+## 0.6.0
+- Allow Python 2 and 3 versions of package to replace one another
+
 ## 0.5.4
 - Move NMOS packages from recommends to depends
 

--- a/bin/proxylisting
+++ b/bin/proxylisting
@@ -1,5 +1,4 @@
-#!/usr/bin/python
-
+#!/usr/bin/env python3
 from nmosreverseproxy.proxylistingservice import ProxyListingService
 
 if __name__ == "__main__":

--- a/debian/ips-reverseproxy-common.install
+++ b/debian/ips-reverseproxy-common.install
@@ -1,2 +1,0 @@
-nmosreverseproxy* usr/lib/python2.7/dist-packages
-bin/proxylisting usr/bin

--- a/debian/ips-reverseproxy-common.service
+++ b/debian/ips-reverseproxy-common.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=/usr/bin/proxylisting
+ExecStart=python2 /usr/bin/proxylisting
 User=ipstudio
 
 [Install]

--- a/debian/ips-reverseproxy-common.service
+++ b/debian/ips-reverseproxy-common.service
@@ -4,7 +4,7 @@ Wants=network-online.target
 After=network.target network-online.target
 
 [Service]
-ExecStart=python2 /usr/bin/proxylisting
+ExecStart=/usr/bin/python2 /usr/bin/proxylisting
 User=ipstudio
 
 [Install]

--- a/debian/python3-nmosreverseproxy.service
+++ b/debian/python3-nmosreverseproxy.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=ips-reverseproxy-common
+Description=nmosreverseproxy
 Wants=network-online.target
 After=network.target network-online.target
 

--- a/rpm/nmos-reverseproxy-common.spec
+++ b/rpm/nmos-reverseproxy-common.spec
@@ -1,5 +1,5 @@
 Name: ips-reverseproxy-common
-Version: 0.5.4
+Version: 0.6.0
 Release: 2%{?dist}
 License: Apache 2
 Summary: Common reverse proxy config for IP Studio web services

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 
 # Basic metadata
 name = "nmosreverseproxy"
-version = "0.5.4"
+version = "0.6.0"
 description = "Reverse Proxy Directory listing service and Apache 2 configuration for NMOS services"
 url = 'https://github.com/bbc/nmos-reverse-proxy'
 author = 'Simon Rankine'

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,8 @@ long_description = description
 
 def is_package(path):
     return (
-        os.path.isdir(path) and
-        os.path.isfile(os.path.join(path, '__init__.py'))
-        )
+        os.path.isdir(path) and os.path.isfile(os.path.join(path, '__init__.py'))
+    )
 
 
 def find_packages(path, base=""):
@@ -58,18 +57,20 @@ packages_required = [
 # eg. https://github.com/bbc/rd-apmm-python-lib-nmos-common#egg=nmoscommon=0.1.0
 deps_required = []
 
-setup(name=name,
-      version=version,
-      description=description,
-      url=url,
-      author=author,
-      author_email=author_email,
-      license=license,
-      packages=package_names,
-      package_dir=packages,
-      install_requires=packages_required,
-      scripts=[],
-      data_files=[
-            ('/usr/bin', ['bin/proxylisting'])
-      ],
-      long_description=long_description)
+setup(
+    name=name,
+    version=version,
+    description=description,
+    url=url,
+    author=author,
+    author_email=author_email,
+    license=license,
+    packages=package_names,
+    package_dir=packages,
+    install_requires=packages_required,
+    scripts=[],
+    data_files=[
+        ('/usr/bin', ['bin/proxylisting'])
+    ],
+    long_description=long_description
+)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,11 @@
 [DEFAULT]
-Depends: apache2, apache2-bin (>=2.4.18) | libapache2-mod-proxy-html, ssl-cert, libxml2-dev, python-nmoscommon 
-Depends3: apache2, apache2-bin (>=2.4.18) | libapache2-mod-proxy-html, ssl-cert, libxml2-dev, python3-nmoscommon 
+Depends: apache2, apache2-bin (>=2.4.18) | libapache2-mod-proxy-html, ssl-cert, libxml2-dev, python-nmoscommon
+Depends3: apache2, apache2-bin (>=2.4.18) | libapache2-mod-proxy-html, ssl-cert, libxml2-dev, python3-nmoscommon
 Build-Depends: apache2-dev, dh-python, dh-systemd
 Package: ips-reverseproxy-common
+Provides: python3-nmosreverseproxy
+Conflicts: python3-nmosreverseproxy
+Replaces: python3-nmosreverseproxy
+Provides3: ips-reverseproxy-common
+Conflicts3: ips-reverseproxy-common
+Replaces3: ips-reverseproxy-common


### PR DESCRIPTION
Hoping that this will allow both packages to over-ride each other, so python2 and 3 packages that depend on the reverse proxy can be installed without a clash. Added a `python2` explicit call in the service file for the python 2 package to override the shebang statement in the binary (which has been changed to python3)